### PR TITLE
add support for shortname definition like ~~DISQUS shortname~~

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,5 +1,5 @@
 div.dokuwiki div#disqus__thread {
-    width: 80%;
+    width: 100%;
     margin: 0;
     padding: 0;
 }

--- a/syntax.php
+++ b/syntax.php
@@ -3,6 +3,7 @@
  *
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author     Andreas Gohr <andi@splitbrain.org>
+ * @author     Fernando Ribeiro <pinguim.ribeiro@gmail.com>
  */
 
 if(!defined('DOKU_INC')) define('DOKU_INC',realpath(dirname(__FILE__).'/../../').'/');
@@ -38,14 +39,19 @@ class syntax_plugin_disqus extends DokuWiki_Syntax_Plugin {
      * Connect pattern to lexer
      */
     function connectTo($mode) {
-      $this->Lexer->addSpecialPattern('~~DISQUS~~',$mode,'plugin_disqus');
+      $this->Lexer->addSpecialPattern('~~DISQUS\b.*?~~',$mode,'plugin_disqus');
     }
 
     /**
      * Handle the match
      */
     function handle($match, $state, $pos, &$handler){
-        return array();
+
+    	$match = substr($match, 8, -2);         //strip ~~DISQUS from start and ~~ from end
+        $shortname = strtolower(trim($match));  //strip spaces
+
+        if (!$shortname) $shortname = $this->getConf('shortname');
+        return $shortname;
     }
 
     /**
@@ -53,11 +59,11 @@ class syntax_plugin_disqus extends DokuWiki_Syntax_Plugin {
      */
     function render($mode, &$R, $data) {
         if($mode != 'xhtml') return false;
-        $R->doc .= $this->_disqus();
+        $R->doc .= $this->_disqus($data);
         return true;
     }
 
-    function _disqus(){
+    function _disqus($shortname){
         global $ID;
         global $INFO;
 
@@ -73,8 +79,8 @@ class syntax_plugin_disqus extends DokuWiki_Syntax_Plugin {
                     //--><!]]>
                     </script>';
         $doc .= '<div id="disqus__thread"></div>';
-        $doc .= '<script type="text/javascript" src="http://disqus.com/forums/'.$this->getConf('shortname').'/embed.js"></script>';
-        $doc .= '<noscript><a href="http://'.$this->getConf('shortname').'.disqus.com/?url=ref">View the discussion thread.</a></noscript>';
+        $doc .= '<script type="text/javascript" src="http://disqus.com/forums/'.$shortname.'/embed.js"></script>';
+        $doc .= '<noscript><a href="http://'.$shortname.'.disqus.com/?url=ref">View the discussion thread.</a></noscript>';
 
         return $doc;
     }

--- a/syntax.php
+++ b/syntax.php
@@ -78,8 +78,8 @@ class syntax_plugin_disqus extends DokuWiki_Syntax_Plugin {
                     //--><!]]>
                     </script>';
         $doc .= '<div id="disqus__thread"></div>';
-        $doc .= '<script type="text/javascript" src="http://disqus.com/forums/'.$shortname.'/embed.js"></script>';
-        $doc .= '<noscript><a href="http://'.$shortname.'.disqus.com/?url=ref">View the discussion thread.</a></noscript>';
+        $doc .= '<script type="text/javascript" src="https://disqus.com/forums/'.$shortname.'/embed.js"></script>';
+        $doc .= '<noscript><a href="https://'.$shortname.'.disqus.com/?url=ref">View the discussion thread.</a></noscript>';
 
         return $doc;
     }

--- a/syntax.php
+++ b/syntax.php
@@ -3,7 +3,6 @@
  *
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author     Andreas Gohr <andi@splitbrain.org>
- * @author     Fernando Ribeiro <pinguim.ribeiro@gmail.com>
  */
 
 if(!defined('DOKU_INC')) define('DOKU_INC',realpath(dirname(__FILE__).'/../../').'/');


### PR DESCRIPTION
add support for shortname definition like 
 ~~DISQUS shortname ~~ 
in order to use it in multilingual sites
the default syntax still works with the default parameters:
 ~~DISQUS ~~ 
