### PR TITLE
Use relative reference instead of http

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -73,8 +73,8 @@ class syntax_plugin_disqus extends DokuWiki_Syntax_Plugin {
                     //--><!]]>
                     </script>';
         $doc .= '<div id="disqus__thread"></div>';
-        $doc .= '<script type="text/javascript" src="http://disqus.com/forums/'.$this->getConf('shortname').'/embed.js"></script>';
-        $doc .= '<noscript><a href="http://'.$this->getConf('shortname').'.disqus.com/?url=ref">View the discussion thread.</a></noscript>';
+        $doc .= '<script type="text/javascript" src="//disqus.com/forums/'.$this->getConf('shortname').'/embed.js"></script>';
+        $doc .= '<noscript><a href="//'.$this->getConf('shortname').'.disqus.com/?url=ref">View the discussion thread.</a></noscript>';
 
         return $doc;
     }


### PR DESCRIPTION
Per RFC 3986, Section 4.2[1], it's possible to specify URL in relative format (// instead of protocol://).  This allows using disqus plugin on a https site.

[1] http://tools.ietf.org/html/rfc3986#section-4.2
