### PR TITLE
add the ability to define disqus shorname on the fly

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -38,14 +38,19 @@ class syntax_plugin_disqus extends DokuWiki_Syntax_Plugin {
      * Connect pattern to lexer
      */
     function connectTo($mode) {
-      $this->Lexer->addSpecialPattern('~~DISQUS~~',$mode,'plugin_disqus');
+      $this->Lexer->addSpecialPattern('~~DISQUS\b.*?~~',$mode,'plugin_disqus');
     }
 
     /**
      * Handle the match
      */
     function handle($match, $state, $pos, Doku_Handler $handler){
-        return array();
+
+        $match = substr($match, 8, -2);         //strip ~~DISQUS from start and ~~ from end
+        $shortname = strtolower(trim($match));  //strip spaces
+
+        if (!$shortname) $shortname = $this->getConf('shortname');
+        return $shortname;
     }
 
     /**
@@ -53,11 +58,11 @@ class syntax_plugin_disqus extends DokuWiki_Syntax_Plugin {
      */
     function render($mode, Doku_Renderer $R, $data) {
         if($mode != 'xhtml') return false;
-        $R->doc .= $this->_disqus();
+        $R->doc .= $this->_disqus($data);
         return true;
     }
 
-    function _disqus(){
+    function _disqus($shortname){
         global $ID;
         global $INFO;
 
@@ -73,8 +78,8 @@ class syntax_plugin_disqus extends DokuWiki_Syntax_Plugin {
                     //--><!]]>
                     </script>';
         $doc .= '<div id="disqus__thread"></div>';
-        $doc .= '<script type="text/javascript" src="//disqus.com/forums/'.$this->getConf('shortname').'/embed.js"></script>';
-        $doc .= '<noscript><a href="//'.$this->getConf('shortname').'.disqus.com/?url=ref">View the discussion thread.</a></noscript>';
+        $doc .= '<script type="text/javascript" src="//disqus.com/forums/'.$shortname.'/embed.js"></script>';
+        $doc .= '<noscript><a href="//'.$shortname.'.disqus.com/?url=ref">View the discussion thread.</a></noscript>';
 
         return $doc;
     }

--- a/syntax.php
+++ b/syntax.php
@@ -50,7 +50,7 @@ class syntax_plugin_disqus extends DokuWiki_Syntax_Plugin {
         $shortname = strtolower(trim($match));  //strip spaces
 
         if (!$shortname) $shortname = $this->getConf('shortname');
-        return hsc($shortname);
+        return $shortname;
     }
 
     /**
@@ -78,8 +78,8 @@ class syntax_plugin_disqus extends DokuWiki_Syntax_Plugin {
                     //--><!]]>
                     </script>';
         $doc .= '<div id="disqus__thread"></div>';
-        $doc .= '<script type="text/javascript" src="//disqus.com/forums/'.$shortname.'/embed.js"></script>';
-        $doc .= '<noscript><a href="//'.$shortname.'.disqus.com/?url=ref">View the discussion thread.</a></noscript>';
+        $doc .= '<script type="text/javascript" src="//disqus.com/forums/'.hsc($shortname).'/embed.js"></script>';
+        $doc .= '<noscript><a href="//'.hsc($shortname).'.disqus.com/?url=ref">View the discussion thread.</a></noscript>';
 
         return $doc;
     }

--- a/syntax.php
+++ b/syntax.php
@@ -50,7 +50,7 @@ class syntax_plugin_disqus extends DokuWiki_Syntax_Plugin {
         $shortname = strtolower(trim($match));  //strip spaces
 
         if (!$shortname) $shortname = $this->getConf('shortname');
-        return $shortname;
+        return hsc($shortname);
     }
 
     /**


### PR DESCRIPTION
Hi,

This adds the ability to define disqus "sortname" inline, using the syntax:

`~~DISQUS myshortname~~`

The default syntax is still valid:

`~~DISQUS~~`

I’m using it in order to provide localized comments in multilingual sites.

This replaces my previous PR made by mistake :-(

Please feel free to accept or delete this PR.

Thanks for you great work!
